### PR TITLE
Fixed small issue where expired entries wouldn't be removed from the dictionary file, resulting in very large files in the long run.

### DIFF
--- a/EGOCache.m
+++ b/EGOCache.m
@@ -96,11 +96,16 @@ static EGOCache* __instance;
                                                attributes:nil 
                                                     error:NULL];
 		
+		NSMutableArray *removeList = [NSMutableArray array];
 		for(NSString* key in cacheDictionary) {
 			NSDate* date = [cacheDictionary objectForKey:key];
 			if([[[NSDate date] earlierDate:date] isEqualToDate:date]) {
+				[removeList addObject:key];
 				[[NSFileManager defaultManager] removeItemAtPath:cachePathForKey(key) error:NULL];
 			}
+		}
+		if ([removeList count] > 0) {
+			[cacheDictionary removeObjectsForKeys:removeList];
 		}
 	}
 	


### PR DESCRIPTION
This is related to issue #10. I'm simply adding the dictionary entries that are expired into a separate list to be removed from the internal cache dictionary.

As I mentioned on that other issue, I had a client where this dictionary plist file grew very large after a few months worth of usage.
