### PR TITLE
Fix: Error when using setImage:forKey on Mac OS

### DIFF
--- a/EGOCache.m
+++ b/EGOCache.m
@@ -257,8 +257,14 @@ static EGOCache* __instance;
 }
 
 - (void)setImage:(NSImage*)anImage forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
-	[self setData:[[[anImage representations] objectAtIndex:0] representationUsingType:NSPNGFileType properties:nil]
-         forKey:key withTimeoutInterval:timeoutInterval];
+	[self setData:[self NSImagePNGRepresentation:anImage] forKey:key withTimeoutInterval:timeoutInterval];
+}
+
+- (NSData *)NSImagePNGRepresentation:(NSImage *)img {
+    [img lockFocus];
+    NSBitmapImageRep *imgBitmapRep = [[NSBitmapImageRep alloc] initWithFocusedViewRect:NSMakeRect(0.0, 0.0, [img size].width, [img size].height)] ;
+    [img unlockFocus] ;
+    return [imgBitmapRep representationUsingType:NSPNGFileType properties:nil];
 }
 
 #endif


### PR DESCRIPTION
[[anImage representations] objectAtIndex:0] returns an NSCGImageSnapshotRep
which does not respond to representationUsingType:properties
and leads to this error
[NSCGImageSnapshotRep representationUsingType:properties:]: unrecognized selector sent to instance.

Plus, NSCGImageSnapshotRep seems to be private and isn't officially documented .

NSBitmapImageRep DOES respond to representationUsingType:properties.
So I create the NSBitmapImageRep from the NSImage and then use representationUsingType:properties to return the NSData.
This NSImagePNGRepresentation method could/should be in an NSImage Category.
