### PR TITLE
Add dateForKey and allKeys methods

### DIFF
--- a/EGOCache.h
+++ b/EGOCache.h
@@ -53,6 +53,9 @@
 - (void)setString:(NSString*)aString forKey:(NSString*)key;
 - (void)setString:(NSString*)aString forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
 
+- (NSDate*)dateForKey:(NSString*)key;
+- (NSArray*)allKeys;
+
 #if TARGET_OS_IPHONE
 - (UIImage*)imageForKey:(NSString*)key;
 - (void)setImage:(UIImage*)anImage forKey:(NSString*)key;

--- a/EGOCache.m
+++ b/EGOCache.m
@@ -152,16 +152,31 @@ static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
 }
 
 - (BOOL)hasCacheForKey:(NSString*)key {
-	__block NSDate* date = nil;;
-	
-	dispatch_sync(_frozenCacheInfoQueue, ^{
-		date = (self.frozenCacheInfo)[key];
-	});
-	
+    NSDate* date = [self dateForKey:key];
 	if(!date) return NO;
 	if([date compare:[NSDate date]] != NSOrderedDescending) return NO;
 	
 	return [[NSFileManager defaultManager] fileExistsAtPath:cachePathForKey(_directory, key)];
+}
+
+- (NSDate*)dateForKey:(NSString*)key {
+	__block NSDate* date = nil;
+
+	dispatch_sync(_frozenCacheInfoQueue, ^{
+		date = (self.frozenCacheInfo)[key];
+	});
+
+    return date;
+}
+
+- (NSArray*)allKeys {
+    __block NSArray* keys = nil;
+
+    dispatch_sync(_frozenCacheInfoQueue, ^{
+        keys = [self.frozenCacheInfo allKeys];
+    });
+
+    return keys;
 }
 
 - (void)setCacheTimeoutInterval:(NSTimeInterval)timeoutInterval forKey:(NSString*)key {


### PR DESCRIPTION
Iterating over all keys in the cache and checking the age is useful and enables implementing custom cache invalidation strategies. Thanks!
