### PR TITLE
Add JSON Object Methods

### DIFF
--- a/EGOCache.h
+++ b/EGOCache.h
@@ -70,6 +70,11 @@
 - (void)setPlist:(id)plistObject forKey:(NSString*)key;
 - (void)setPlist:(id)plistObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
 
+- (id)jsonObjectForKey:(NSString*)key;
+- (id)mutableJsonObjectForKey:(NSString*)key;
+- (void)setJson:(id)jsonObject forKey:(NSString*)key;
+- (void)setJson:(id)jsonObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
 - (void)copyFilePath:(NSString*)filePath asKey:(NSString*)key;
 - (void)copyFilePath:(NSString*)filePath asKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;	
 

--- a/EGOCache.m
+++ b/EGOCache.m
@@ -358,6 +358,33 @@ static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
 }
 
 #pragma mark -
+#pragma mark JSON Object methods
+
+- (id)jsonObjectForKey:(NSString*)key {
+	NSData* jsonData = [self dataForKey:key];
+
+	return [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingAllowFragments error:nil];
+
+}
+
+- (id)mutableJsonObjectForKey:(NSString*)key {
+	NSData* jsonData = [self dataForKey:key];
+
+	return [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingMutableContainers error:nil];
+
+}
+
+- (void)setJson:(id)jsonObject forKey:(NSString*)key {
+	[self setJson:jsonObject forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setJson:(id)jsonObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+	NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:nil];
+
+	[self setData:jsonData forKey:key withTimeoutInterval:timeoutInterval];
+}
+
+#pragma mark -
 #pragma mark Object methods
 
 - (id<NSCoding>)objectForKey:(NSString*)key {


### PR DESCRIPTION
This adds methods to use `NSJSONSerialization` instead of `NSPropertyListSerialization`. This is much safer when your data is download as `JSON` and may contain `NULL` values since `NSPropertyListSerialization` can not store `NULL` values. It also works nicely when you need to modify the data frequently since we can take advantage of `NSJSONReadingMutableContainers`.
