### PR TITLE
Method that blocks current thread until disk writes finish

### DIFF
--- a/EGOCache.h
+++ b/EGOCache.h
@@ -77,5 +77,7 @@
 - (void)setObject:(id<NSCoding>)anObject forKey:(NSString*)key;
 - (void)setObject:(id<NSCoding>)anObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
 
+- (void)waitForDiskWrites;
+
 @property(nonatomic,assign) NSTimeInterval defaultTimeoutInterval; // Default is 1 day
 @end

--- a/EGOCache.m
+++ b/EGOCache.m
@@ -377,6 +377,14 @@ static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
 }
 
 #pragma mark -
+#pragma mark Synchronisation
+
+- (void)waitForDiskWrites
+{
+    dispatch_sync(_diskQueue,^{});
+}
+
+#pragma mark -
 
 - (void)dealloc {
 


### PR DESCRIPTION
I had the need to wait until all disk writes completed before commencing another operation so added a simple dispatch sync method. Perhaps this will be useful to someone.
