### PR TITLE
Remove error in Xcode 7

### DIFF
--- a/EGOCache.m
+++ b/EGOCache.m
@@ -325,7 +325,8 @@ static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
 }
 
 - (void)setImage:(NSImage*)anImage forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
-	[self setData:[[[anImage representations] objectAtIndex:0] representationUsingType:NSPNGFileType properties:nil] forKey:key withTimeoutInterval:timeoutInterval];
+	NSBitmapImageRep *bitmapRep = anImage.representations.firstObject;
+	[self setData:[bitmapRep representationUsingType:NSPNGFileType properties:nil] forKey:key withTimeoutInterval:timeoutInterval];
 }
 
 #endif

--- a/EGOCache.m
+++ b/EGOCache.m
@@ -325,8 +325,8 @@ static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
 }
 
 - (void)setImage:(NSImage*)anImage forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
-	NSBitmapImageRep *bitmapRep = anImage.representations.firstObject;
-	[self setData:[bitmapRep representationUsingType:NSPNGFileType properties:nil] forKey:key withTimeoutInterval:timeoutInterval];
+	NSBitmapImageRep *bitmapRep = (id)anImage.representations.firstObject;
+	[self setData:[bitmapRep representationUsingType:NSPNGFileType properties:@{}] forKey:key withTimeoutInterval:timeoutInterval];
 }
 
 #endif


### PR DESCRIPTION
Because of generics the method `objectAtIndex:` does not return `id` anymore.
